### PR TITLE
ps-emacs now lists emacsclient processes + non-TTY emacs processes

### DIFF
--- a/bin/other/ps-emacs-format.awk
+++ b/bin/other/ps-emacs-format.awk
@@ -3,7 +3,7 @@
 # Purpose   : Format Emacs process list to add the CWD to the line.
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2025-09-29 23:08:47 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-02-26 11:11:14 EST, updated by Pierre Rouleau>
 # ------------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -45,10 +45,12 @@
 # On all lines, extract the process id (from column 2) and use the pidcwd
 # program to extract the current working directory of that process.
 # print the line and then the current working directory.
-$8 == "emacs"  {
+$8 ~ "emacs"  {
       command = "pidcwd " $2
       command |& getline path_result
       close(command)
       print $0, "  ▶︎▶︎▶︎ CWD: ", path_result
 }
+
+#
 # ------------------------------------------------------------------------------

--- a/bin/ps-emacs
+++ b/bin/ps-emacs
@@ -1,15 +1,21 @@
 #!/bin/sh
 # SH FILE: ps-emacs
 #
-# Purpose   : List all running Emacs processes running inside a Terminal.
+# Purpose   : List all running Emacs processes.
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-02-18 16:51:03 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-02-26 11:15:47 EST, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
+
 # Module Description
 # ------------------
 #
-# Print information about all Emacs processes running inside a terminal window.
+# Print information about all Emacs processes running.
+# For those inside a terminal window, identify the terminal as nicely as
+# possible.  List the Emacs processes not running inside a terminal window
+# after the list of Emacs running inside a terminal window.
+
+
 
 # ----------------------------------------------------------------------------
 # Dependencies
@@ -32,7 +38,10 @@
 print_usage()
 {
     printf -- "
-ps-emacs -- Print information about all Emacs process running in a terminal.
+ps-emacs -- Print information about all Emacs processes.
+            List Emacs processes running in terminal windows first, identify
+            the terminal as nicely as possible for those.
+            List other Emacs processes after.
 
  Usage: ps-emacs -h | --help
 
@@ -86,7 +95,7 @@ fi
 
 print_emacs_processes()
 {
-    # List all Emacs processes
+    # List all Emacs processes running inside terminal windows first.
     #  - filter out itself (ps-emacs)
     #  - filter on tty to only list processes attached to a TTY
     #    - under macOS it's tty, under linux it's pts/
@@ -95,6 +104,7 @@ print_emacs_processes()
     #    and append it to the output.
     #    The AWK script also prints "  ▶︎▶︎▶︎ CWD: " before the current directory
     #    and filters on the process being Emacs.
+    # Note this also lists emacsclient processes.
     if [ "$use_gawk" = "true" ]; then
         ps-list emacs \
             | grep " tty\|pts/" \
@@ -105,6 +115,9 @@ print_emacs_processes()
             | grep " tty\|pts/" \
             | awk -f "$USRHOME_DIR/bin/other/ps-emacs.awk"
     fi
+    # List all other Emacs processes not running in terminal windows (if any).
+    # Exclude Emacs child processes (by grepping on " emacs ")
+    ps-list emacs | grep " emacs " | grep -v " tty\|pts/"
 }
 
 # --

--- a/bin/ps-emacs
+++ b/bin/ps-emacs
@@ -4,7 +4,7 @@
 # Purpose   : List all running Emacs processes.
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-02-26 11:15:47 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-02-26 11:31:58 EST, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 
 # Module Description
@@ -49,7 +49,7 @@ ps-emacs -- Print information about all Emacs processes.
 
  Usage: ps-emacs [PATTERN]
 
-  • Print information about all Emacs processes running in a terminal.
+  • Print information about all running Emacs processes.
 
       Print a line for each Emacs process.
       Each line contains the following columns.
@@ -116,8 +116,7 @@ print_emacs_processes()
             | awk -f "$USRHOME_DIR/bin/other/ps-emacs.awk"
     fi
     # List all other Emacs processes not running in terminal windows (if any).
-    # Exclude Emacs child processes (by grepping on " emacs ")
-    ps-list emacs | grep " emacs " | grep -v " tty\|pts/"
+    ps-list emacs | awk '$6 !~ /(tty|pts\/)/ && $8 ~ /(^|\/)emacs(client)?$/'
 }
 
 # --


### PR DESCRIPTION
* ps-emacs script explicitly lists non terminal Emacs processes after the list of terminal processes.
* The ps-emacs-format.awk no longer exclude emacsclient by matching anything that has "emacs" inside the 8th field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Emacs process listing to show all running instances, presenting terminal-based processes first with terminal identifiers.

* **Bug Fixes**
  * Improved matching so a wider range of Emacs-related processes are correctly detected and included.

* **Documentation**
  * Clarified help/usage text and module description to explain ordering and inclusion of terminal and non-terminal processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->