### PR TITLE
ps-list -i for case-insensitive. ps-emacs improvements.

### DIFF
--- a/bin/ps-emacs
+++ b/bin/ps-emacs
@@ -4,7 +4,7 @@
 # Purpose   : List all running Emacs processes.
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-03-03 14:29:53 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-03-03 14:46:24 EST, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 
 # Module Description
@@ -71,7 +71,9 @@ ps-emacs -- Print information about all Emacs processes.
     - If PATTERN is specified, filter the result with an extra grep filter
       using that pattern.  That can be used to search for an Emacs process
       launched under a specific command, or using a specific working directory.
-    - Under macOS it is best to use gawk (GNU awk) which supports case
+    - Under macOS it is best to use gawk (GNU awk) which supports a script that
+      deals with terminal number reformatting and allows printing the terminal
+      (TTY) numbers nicely on the output.
 
     The exit code is 0 if at least one Emacs process was found, 1 otherwise.
 "
@@ -90,12 +92,12 @@ fi
 # define utility
 
 case_sensitive=yes
-use_gawk=false
+use_gawk=no
 
 case "$(uname)" in
     Darwin)
         if command -v gawk > /dev/null; then
-            use_gawk=true
+            use_gawk=yes
         fi
         case_sensitive=no
         ;;
@@ -107,7 +109,7 @@ case "$(uname)" in
 
     Linux)
         if command -v gawk > /dev/null; then
-            use_gawk=true
+            use_gawk=yes
         fi
         case_sensitive=yes
         ;;
@@ -135,21 +137,21 @@ print_emacs_processes()
     #    The AWK script also prints "  ▶︎▶︎▶︎ CWD: " before the current directory
     #    and filters on the process being Emacs.
     # Note this also lists emacsclient processes.
-    if [ "$use_gawk" = "true" ]; then
+    if [ "$use_gawk" = "yes" ]; then
         ps_list_emacs \
             | grep " tty\|pts/" \
             | gawk '$8 ~ /(^|\/)[eE]macs(client)?$/' \
             | gawk -f "$USRHOME_DIR/bin/other/ps-emacs-format.awk" \
             | column -s "▶︎▶︎▶︎" -t
         # List all other Emacs processes not running in terminal windows (if any).
-        ps_list_emacs | gawk '$6 ~ /\?\?/' | gawk '$8 ~ /(^|\/)[eE]macs((\.app)|(client))?/'
+        ps_list_emacs | gawk '$6 !~ /(tty|pts\/)/' | gawk '$8 ~ /(^|\/)[eE]macs((\.app)|(client))?/'
     else
         ps_list_emacs \
             | grep " tty\|pts/" \
             | awk '$8 ~ /(^|\/)[eE]macs(client)?$/' \
             | awk -f "$USRHOME_DIR/bin/other/ps-emacs.awk"
         # List all other Emacs processes not running in terminal windows (if any).
-        ps_list_emacs | awk '$6 !~ /(tty|pts\/)/ && $8 ~ /(^|\/)[eE]macs((\.app)|(client)?$/'
+        ps_list_emacs | awk '$6 !~ /(tty|pts\/)/ && $8 ~ /(^|\/)[eE]macs((\.app)|(client)?)/'
     fi
 
 }

--- a/bin/ps-emacs
+++ b/bin/ps-emacs
@@ -4,7 +4,7 @@
 # Purpose   : List all running Emacs processes.
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-03-03 14:46:24 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-03-03 14:51:57 EST, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 
 # Module Description
@@ -151,7 +151,7 @@ print_emacs_processes()
             | awk '$8 ~ /(^|\/)[eE]macs(client)?$/' \
             | awk -f "$USRHOME_DIR/bin/other/ps-emacs.awk"
         # List all other Emacs processes not running in terminal windows (if any).
-        ps_list_emacs | awk '$6 !~ /(tty|pts\/)/ && $8 ~ /(^|\/)[eE]macs((\.app)|(client)?)/'
+        ps_list_emacs | awk '$6 !~ /(tty|pts\/)/ && $8 ~ /(^|\/)[eE]macs((\.app)|(client))?/'
     fi
 
 }

--- a/bin/ps-emacs
+++ b/bin/ps-emacs
@@ -4,7 +4,7 @@
 # Purpose   : List all running Emacs processes.
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-03-03 12:05:31 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-03-03 14:29:53 EST, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 
 # Module Description
@@ -39,9 +39,9 @@ print_usage()
 {
     printf -- "
 ps-emacs -- Print information about all Emacs processes.
-            List Emacs processes running in terminal windows first, identify
-            the terminal as nicely as possible for those.
-            List other Emacs processes after.
+            List Emacs processes running in terminal windows first,
+            identify the terminal as nicely as possible for those.
+            Then list other Emacs processes (such as GUI Emacs).
 
  Usage: ps-emacs -h | --help
 
@@ -71,6 +71,7 @@ ps-emacs -- Print information about all Emacs processes.
     - If PATTERN is specified, filter the result with an extra grep filter
       using that pattern.  That can be used to search for an Emacs process
       launched under a specific command, or using a specific working directory.
+    - Under macOS it is best to use gawk (GNU awk) which supports case
 
     The exit code is 0 if at least one Emacs process was found, 1 otherwise.
 "
@@ -88,10 +89,39 @@ fi
 # --
 # define utility
 
+case_sensitive=yes
 use_gawk=false
-if command -v gawk > /dev/null; then
-    use_gawk=true
-fi
+
+case "$(uname)" in
+    Darwin)
+        if command -v gawk > /dev/null; then
+            use_gawk=true
+        fi
+        case_sensitive=no
+        ;;
+
+    CYGWIN*|MSYS*|MINGW*|WindowsNT*)
+        # attempt to support this environment, but no guarantee...
+        case_sensitive=no
+        ;;
+
+    Linux)
+        if command -v gawk > /dev/null; then
+            use_gawk=true
+        fi
+        case_sensitive=yes
+        ;;
+esac
+
+ps_list_emacs()
+{
+    if [ "${case_sensitive}" = "yes" ]; then
+        ps-list emacs
+    else
+        ps-list -i emacs
+    fi
+}
+
 
 print_emacs_processes()
 {
@@ -106,17 +136,22 @@ print_emacs_processes()
     #    and filters on the process being Emacs.
     # Note this also lists emacsclient processes.
     if [ "$use_gawk" = "true" ]; then
-        ps-list "emacs " \
+        ps_list_emacs \
             | grep " tty\|pts/" \
+            | gawk '$8 ~ /(^|\/)[eE]macs(client)?$/' \
             | gawk -f "$USRHOME_DIR/bin/other/ps-emacs-format.awk" \
             | column -s "▶︎▶︎▶︎" -t
+        # List all other Emacs processes not running in terminal windows (if any).
+        ps_list_emacs | gawk '$6 ~ /\?\?/' | gawk '$8 ~ /(^|\/)[eE]macs((\.app)|(client))?/'
     else
-        ps-list "emacs " \
+        ps_list_emacs \
             | grep " tty\|pts/" \
+            | awk '$8 ~ /(^|\/)[eE]macs(client)?$/' \
             | awk -f "$USRHOME_DIR/bin/other/ps-emacs.awk"
+        # List all other Emacs processes not running in terminal windows (if any).
+        ps_list_emacs | awk '$6 !~ /(tty|pts\/)/ && $8 ~ /(^|\/)[eE]macs((\.app)|(client)?$/'
     fi
-    # List all other Emacs processes not running in terminal windows (if any).
-    ps-list "emacs " | awk '$6 !~ /(tty|pts\/)/ && $8 ~ /(^|\/)emacs(client)?$/'
+
 }
 
 # --

--- a/bin/ps-list
+++ b/bin/ps-list
@@ -4,7 +4,7 @@
 # Purpose   : List running Processes.
 # Created   : Saturday, March  1 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-02-18 16:52:39 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-03-03 14:28:52 EST, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -41,10 +41,11 @@ print_usage()
  Usage: %s h|--help
  • Print this help information.
 
- Usage: %s [-Z] PROCESS
+ Usage: %s [-i] [-Z] PROCESS
  • Print information related to running PROCESS specified by name.
 
  Options:
+        -i : case insensitive search.
         -Z : include SELinux security context labels.
              Only available on Linux where SELinux is available.
              On this system, SELinux is %savailable.
@@ -87,6 +88,12 @@ fi
 # --
 # proceed
 
+case_insensitive=no
+if [ "$1" = "-i" ]; then
+    case_insensitive=yes
+    shift
+fi
+
 ps_options=
 if [ "$1" = "-Z" ]; then
     if [ "$selinux_is_available" = "true" ]; then
@@ -100,6 +107,10 @@ fi
 
 # -f Print command arguments
 # shellcheck disable=SC2009
-ps -ef $ps_options | grep "$1" | grep -v "$pgm_name" | grep -v grep
+if [ "${case_insensitive}" = "yes" ]; then
+    ps -ef $ps_options | grep -i "$1" | grep -v "$pgm_name" | grep -v grep
+else
+    ps -ef $ps_options | grep    "$1" | grep -v "$pgm_name" | grep -v grep
+fi
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
    * The ps-list now supports a -i option to perform a case insensitive grep.
    * Improve ps-emacs:
      - Allow it to detect macOS GUI Emacs (via a search on Emacs.app).
      - On Linux, with gawk available, allow nice rendering of terminal info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added case-insensitive search option (`-i`) for process listings.
  * Improved cross-platform process filtering to clearly separate terminal and non-terminal Emacs instances; macOS now recommends GNU awk for correct TTY formatting.

* **Documentation**
  * Help/usage updated to state terminal-first listing, then non-terminal (GUI) Emacs, and to note gawk recommendation on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->