### PR TITLE
Pike support check. lsd and lsda are alias to lsdd when Pike used

### DIFF
--- a/ibin/setfor-alias
+++ b/ibin/setfor-alias
@@ -3,7 +3,7 @@
 # Purpose   : Set USRHOME command aliases common to bash and zsh shells.
 # Created   : Friday, April 12 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-24 19:59:18 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-25 16:05:28 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -82,6 +82,17 @@ usrhome_printf()
         printf -- "$@"
     fi
 }
+
+usrhome_print_error()
+{
+    # Arg: $1
+    # Print test of Arg after **ERROR: prefix in red.
+    _usrhome_RED='\033[1;31m' # Bold red
+    _usrhome_NC='\033[0m' # No Color
+    printf "${_usrhome_RED}** ERROR: %s${_usrhome_NC}\n" "$1"
+    unset _usrhome_RED _usrhome_NC
+}
+
 
 info_shell_special_var()
 {
@@ -251,72 +262,78 @@ __set__ls_options()
     esac
 }
 
+if [ -z "$USRHOME_USE_PIKE" ] || [ "$USRHOME_USE_PIKE" = "0" ]; then
 # List directories
-lsd()
-{
-    __set__ls_options
-    if [ -z "$1" ]; then
-        ( ls -d ${_sa_usrhome_ls_color_flag} -- */ ) 2> /dev/null
-    elif [ $# -gt 1 ]; then
-        echo "ERROR: lsd does not support glob, and more than 1 argument."
-        echo "  You provided $# argument."
-        echo " Usage: lsd [ARG]"
-        echo "  ARG: full or partial directory name."
-        return 1
-    else
-        # shellcheck disable=SC2086 # don't quote to allow expansion of globs
-        ( ls -d ${_sa_usrhome_ls_color_flag} -- $1*/ ) 2> /dev/null
-    fi
-    unset _sa_usrhome_ls_color_flag
-}
+    lsd()
+    {
+        __set__ls_options
+        if [ -z "$1" ]; then
+            ( ls -d ${_sa_usrhome_ls_color_flag} -- */ ) 2> /dev/null
+        elif [ $# -gt 1 ]; then
+            echo "ERROR: lsd does not support glob, and more than 1 argument."
+            echo "  You provided $# argument."
+            echo " Usage: lsd [ARG]"
+            echo "  ARG: full or partial directory name."
+            return 1
+        else
+            # shellcheck disable=SC2086 # don't quote to allow expansion of globs
+            ( ls -d ${_sa_usrhome_ls_color_flag} -- $1*/ ) 2> /dev/null
+        fi
+        unset _sa_usrhome_ls_color_flag
+    }
 
-# Note lsda is not reliable.
-#    I will eventually re-implement it in another language.
-lsda()
-{
-    __set__ls_options
-    if [ -z "$1" ]; then
-        # No argument
-        ( ls -d ${_sa_usrhome_ls_color_flag} -- */ .[^.]*/ ) 2> /dev/null
-    elif [ $# -gt 1 ]; then
-        # 2 arguments or more: not allowed.
-        echo "ERROR: lsda does not support glob, and more than 1 argument."
-        echo "  You provided $# argument"
-        echo " Usage: lsda [ARG]"
-        echo "  ARG: full or partial directory name."
-        return 1
-    else
-        # one argument
-        if ls -d -- "$1" > /dev/null 2>&1; then
-            _sa_has_reg=1
+    # Note lsda is not reliable.
+    #    I will eventually re-implement it in another language.
+    lsda()
+    {
+        __set__ls_options
+        if [ -z "$1" ]; then
+            # No argument
+            ( ls -d ${_sa_usrhome_ls_color_flag} -- */ .[^.]*/ ) 2> /dev/null
+        elif [ $# -gt 1 ]; then
+            # 2 arguments or more: not allowed.
+            echo "ERROR: lsda does not support glob, and more than 1 argument."
+            echo "  You provided $# argument"
+            echo " Usage: lsda [ARG]"
+            echo "  ARG: full or partial directory name."
+            return 1
         else
-            _sa_has_reg=0
-        fi
-        if ls -d ".$1" > /dev/null 2>&1; then
-            _sa_has_hid=1
-        else
-            _sa_has_hid=0
-        fi
-        if [ "$_sa_has_reg" = "1" ]; then
-            if [ "$_sa_has_hid" = "1" ]; then
-                echo "has hidden and regular"
-                ( ls -d ${_sa_usrhome_ls_color_flag} -- ".$1" "$1" ) 2> /dev/null
+            # one argument
+            if ls -d -- "$1" > /dev/null 2>&1; then
+                _sa_has_reg=1
             else
-                echo "has regular only"
-                ( ls -d ${_sa_usrhome_ls_color_flag} -- "$1" ) 2> /dev/null
+                _sa_has_reg=0
             fi
-        else
-            if [ "$_sa_has_hid" = "1" ]; then
-                # has hidden only
-                ( ls -d ${_sa_usrhome_ls_color_flag} -- ".$1" ) 2> /dev/null
+            if ls -d ".$1" > /dev/null 2>&1; then
+                _sa_has_hid=1
             else
-                # has nothing
-                return 1
+                _sa_has_hid=0
+            fi
+            if [ "$_sa_has_reg" = "1" ]; then
+                if [ "$_sa_has_hid" = "1" ]; then
+                    echo "has hidden and regular"
+                    ( ls -d ${_sa_usrhome_ls_color_flag} -- ".$1" "$1" ) 2> /dev/null
+                else
+                    echo "has regular only"
+                    ( ls -d ${_sa_usrhome_ls_color_flag} -- "$1" ) 2> /dev/null
+                fi
+            else
+                if [ "$_sa_has_hid" = "1" ]; then
+                    # has hidden only
+                    ( ls -d ${_sa_usrhome_ls_color_flag} -- ".$1" ) 2> /dev/null
+                else
+                    # has nothing
+                    return 1
+                fi
             fi
         fi
-    fi
-    unset _sa_has_reg _sa_has_hid _sa_usrhome_ls_color_flag
-}
+        unset _sa_has_reg _sa_has_hid _sa_usrhome_ls_color_flag
+    }
+elif [ "$USRHOME_USE_PIKE" = "1" ]; then
+    # Topic: Use Pike
+    alias lsd=lsdd
+    alias lsda='lsdd -a'
+fi
 
 # lsl: list symlinks
 lsl()
@@ -377,7 +394,7 @@ lsl()
 if [ "${os_name}" = "Darwin" ]; then
     info__rosetta2()
     {
-        printf "Rosetta 2 is %sinstalled.\n" $(/usr/bin/pgrep -q oahd && echo "" || echo "not ")
+        printf "Rosetta 2 is %sinstalled.\n" "$(/usr/bin/pgrep -q oahd && echo "" || echo "not ")"
         printf " More info is available at:\n"
         printf "  https://eclecticlight.co/2021/01/22/running-intel-code-on-your-m1-mac-rosetta-2-and-oah/\n"
     }

--- a/ibin/setfor-alias
+++ b/ibin/setfor-alias
@@ -3,7 +3,7 @@
 # Purpose   : Set USRHOME command aliases common to bash and zsh shells.
 # Created   : Friday, April 12 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-25 16:05:28 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-25 16:23:47 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -86,11 +86,15 @@ usrhome_printf()
 usrhome_print_error()
 {
     # Arg: $1
-    # Print test of Arg after **ERROR: prefix in red.
-    _usrhome_RED='\033[1;31m' # Bold red
-    _usrhome_NC='\033[0m' # No Color
-    printf "${_usrhome_RED}** ERROR: %s${_usrhome_NC}\n" "$1"
-    unset _usrhome_RED _usrhome_NC
+    # Print Arg text after **ERROR: prefix in red unless TERM=dumb
+    if [ "$TERM" = "dumb" ]; then
+        printf "** ERROR: %s\n" "$1" >&2
+    else
+        _usrhome_RED='\033[1;31m' # Bold red
+        _usrhome_NC='\033[0m' # No Color
+        printf "${_usrhome_RED}** ERROR: %s${_usrhome_NC}\n" "$1" >&2
+        unset _usrhome_RED _usrhome_NC
+    fi
 }
 
 

--- a/ibin/setfor-path
+++ b/ibin/setfor-path
@@ -3,7 +3,7 @@
 # Purpose   : Add USRHOME directories to PATH.
 # Created   : Saturday, March 30 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-02-18 16:58:00 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-25 16:05:52 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -148,6 +148,20 @@ if [ -z "$USRHOME__IN_LOGIN" ] || [ "$USRHOME_CONFIG_AT_LOGIN" = "1" ]; then
             ;;
     esac
     export USRHOME_SHELL_OPEN_TIME
+
+    # ----------------------------------------------------------------------------
+    # Topic: Use Pike
+    # ---------------
+    # In case Pike support is provided by Homebrew its presence must be checked
+    # after Homebrew support is activated in the shell: now it's time.
+    if [ "$USRHOME_USE_PIKE" = "1" ]; then
+        if command -v pike > /dev/null; then
+            printf ". With %s\n" "$(pike --version 2>&1 | head -1)"
+        else
+            usrhome_print_error "USRHOME_USE_PIKE is set to 1 but pike is not found!  Please install Pike!"
+           USRHOME_USE_PIKE=0
+        fi
+    fi
 fi
 
 # ----------------------------------------------------------------------------

--- a/ibin/setfor-path
+++ b/ibin/setfor-path
@@ -3,7 +3,7 @@
 # Purpose   : Add USRHOME directories to PATH.
 # Created   : Saturday, March 30 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-25 16:05:52 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-25 16:31:42 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -154,12 +154,21 @@ if [ -z "$USRHOME__IN_LOGIN" ] || [ "$USRHOME_CONFIG_AT_LOGIN" = "1" ]; then
     # ---------------
     # In case Pike support is provided by Homebrew its presence must be checked
     # after Homebrew support is activated in the shell: now it's time.
+    #
+    # CAUTION: the code report the problem too late and the lsd and lsda are already
+    #          alias to lsdd script that will not work.  This is a limitation of USRHOME design
+    #          that will not change.
+    #          But that's OK: the user should fix his environment by either installing Pike
+    #          or removing the setting of USRHOME_USE_PIKE to 1.
+    #
     if [ "$USRHOME_USE_PIKE" = "1" ]; then
         if command -v pike > /dev/null; then
             printf ". With %s\n" "$(pike --version 2>&1 | head -1)"
         else
             usrhome_print_error "USRHOME_USE_PIKE is set to 1 but pike is not found!  Please install Pike!"
-           USRHOME_USE_PIKE=0
+            USRHOME_USE_PIKE=0
+            # Disable the alias that would not work anyway.
+            unalias lsd lsda 2>/dev/null
         fi
     fi
 fi

--- a/readme.rst
+++ b/readme.rst
@@ -1129,7 +1129,7 @@ USRHOME Command Name               Description
                                    - NAME: optional name or first letters of the names.
 
                                    - If the ``USRHOME_USE_PIKE`` environment variable
-                                     is defined inside your ``$USRCFG/setfor-all-config``
+                                     is set to 1 inside your ``$USRCFG/setfor-all-config``
                                      file, lsd is an alias to the ``lsdd`` tool utility
                                      described below and provides many more features.
 
@@ -1138,7 +1138,7 @@ USRHOME Command Name               Description
 
                                    - NAME: optional name or first letters of the names.
                                    - If the ``USRHOME_USE_PIKE`` environment variable
-                                     is defined inside your ``$USRCFG/setfor-all-config``
+                                     is set to 1 inside your ``$USRCFG/setfor-all-config``
                                      file, lsda is an alias to the ``lsdd -a`` tool utility
                                      described below and provides many more features.
 

--- a/readme.rst
+++ b/readme.rst
@@ -1128,10 +1128,20 @@ USRHOME Command Name               Description
 
                                    - NAME: optional name or first letters of the names.
 
+                                   - If the ``USRHOME_USE_PIKE`` environment variable
+                                     is defined inside your ``$USRCFG/setfor-all-config``
+                                     file, lsd is an alias to the ``lsdd`` tool utility
+                                     described below and provides many more features.
+
 ``lsda [NAME]``                    List sub-directories in current directory,
                                    includes hidden directories.
 
                                    - NAME: optional name or first letters of the names.
+                                   - If the ``USRHOME_USE_PIKE`` environment variable
+                                     is defined inside your ``$USRCFG/setfor-all-config``
+                                     file, lsda is an alias to the ``lsdd -a`` tool utility
+                                     described below and provides many more features.
+
 
 ``lsdd [OPTION] [FILE...]``        List directories only.
 


### PR DESCRIPTION
* The usr can activate explicit use of Pike by setting the USRHOME_USE_PIKE environment variable to 1.
  - When that is done USRHOME startup script checks for the presence of the Pike command.
    - If Pike is present it print its version, if absent it prints an error using a new usrhome_print_error function which prints an error in bold red.
    - When Pike is present lsd and lsda are alias to lsdd; the shells script functions are not created.  This way the user can use more powerful lsd and lsda commands.

The user typically sets USRHOME_USE_PIKE inside $USRCFG/setfor-all-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Pike support for lsd and lsda directory listing commands
  * Improved error message formatting and shell-quoting correctness

* **Documentation**
  * Updated configuration guide describing Pike-based implementation activation and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->