### PR TITLE
Add prepend_to_path and append_to_path shell functions

### DIFF
--- a/ibin/do-add-to-path
+++ b/ibin/do-add-to-path
@@ -3,7 +3,7 @@
 # Purpose   : Add directory to PATH in the current shell
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-27 13:48:44 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:36:28 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -45,6 +45,8 @@ add-to-path -- Add a directory to the beginning or the end of PATH.
              If not specified DIRPATH is placed at the beginning of PATH.
              In both cases DIRPATH can be one directory or a list of
              colon-separated directories.
+
+     CAUTION: shells only expand ~ at the beginning of a string!
 "
 }
 

--- a/ibin/do-add-to-path
+++ b/ibin/do-add-to-path
@@ -3,7 +3,7 @@
 # Purpose   : Add directory to PATH in the current shell
 # Created   : Sunday, September 21 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2025-09-21 11:17:05 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 13:48:44 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -43,6 +43,8 @@ add-to-path -- Add a directory to the beginning or the end of PATH.
 
       --end: add DIRPATH to the end of PATH.
              If not specified DIRPATH is placed at the beginning of PATH.
+             In both cases DIRPATH can be one directory or a list of
+             colon-separated directories.
 "
 }
 
@@ -74,10 +76,11 @@ fi
 
 
 if [ "$at_end" = "true" ]; then
-   export PATH="$PATH:$1" || return 1
+    append_to_path "$1"
 else
-    export PATH="$1:$PATH" || return 1
+    prepend_to_path "$1"
 fi
+export PATH
 
 
 # ----------------------------------------------------------------------------

--- a/ibin/envfor-gcc14-on-macos
+++ b/ibin/envfor-gcc14-on-macos
@@ -3,7 +3,7 @@
 # Purpose   : Activate GCC 14 tool-chain in the current macOS shell.
 # Created   : Sunday, May 26 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2025-08-27 15:24:04 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:03:50 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -31,8 +31,9 @@
 # ------------
 #
 #
-# The $HOME/bin/gcc-14 directory must exists and hold symlinks to the gcc
-# toolchain binaries.
+# - USRHOME function prepend_to_path
+# - The $HOME/bin/gcc-14 directory must exists and hold symlinks to the gcc
+#   toolchain binaries.
 #
 # See $USRHOME_DIR/setup/macos/create-gcc-as-gcc14.sh : it does what's required
 # once you have executed 'brew install gcc' for GCC-14 (which is the current
@@ -71,7 +72,7 @@ if [ -z "$USRHOME_USING_GCC14_ON_MACOS" ]; then
     #   at the beginning, before /usr/bin where the macOS
     #   installed gcc is located.
     #   in case some tools need those.
-    PATH="$HOME/bin/gcc-14:$HOME/bin/aarch64-gcc-14:$PATH"
+    prepend_to_path "$HOME/bin/gcc-14:$HOME/bin/aarch64-gcc-14"
     export PATH
     if [ -z "$LIB" ]; then
         LIB="/opt/homebrew/lib/gcc/current"

--- a/ibin/envfor-gcc15-on-macos
+++ b/ibin/envfor-gcc15-on-macos
@@ -3,7 +3,7 @@
 # Purpose   : Activate GCC 15 tool-chain in the current macOS shell.
 # Created   : Wednesday, August 27 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2025-08-27 15:24:02 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 13:55:05 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -74,7 +74,7 @@ if [ -z "$USRHOME_USING_GCC15_ON_MACOS" ]; then
     #   at the beginning, before /usr/bin where the macOS
     #   installed gcc is located.
     #   in case some tools need those.
-    PATH="$HOME/bin/gcc-15:$HOME/bin/aarch64-gcc-15:$PATH"
+    prepend_to_path "$HOME/bin/gcc-15:$HOME/bin/aarch64-gcc-15"
     export PATH
     if [ -z "$LIB" ]; then
         LIB="/opt/homebrew/lib/gcc/current"

--- a/ibin/envfor-gnu-binutils-on-macos
+++ b/ibin/envfor-gnu-binutils-on-macos
@@ -3,7 +3,7 @@
 # Purpose   : Activate the GNU Binutils Utilities in the current macOS shell.
 # Created   : Tuesday, August 27 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2025-03-24 08:26:28 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:03:20 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -28,7 +28,8 @@
 #       this script.
 #
 #
-# GNU tools that replace macOS native tools:
+# - USRHOME function prepend_to_path
+# - GNU tools that replace macOS native tools:
 #
 # -------------------------- ------------------------- ----------------------
 # macOS native               Gnu equivalent            brew install command
@@ -52,7 +53,7 @@
 # ----
 #
 #
-PATH="/opt/homebrew/opt/binutils/bin:$PATH"
+prepend_to_path "/opt/homebrew/opt/binutils/bin"
 export PATH
 
 # For compilers to find binutils:

--- a/ibin/envfor-gnubin-on-macos
+++ b/ibin/envfor-gnubin-on-macos
@@ -3,7 +3,7 @@
 # Purpose   : Activate GNU grep/egrep/fgrep in current shell.
 # Created   : Thursday, January  8 2026.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-01-08 16:45:28 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:02:58 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 
 # Module Description
@@ -24,14 +24,15 @@
 # Dependencies
 # ------------
 #
-# For macOS using Homebrew.
+# - For macOS using Homebrew.
+# - USRHOME function prepend_to_path
 
 # ----------------------------------------------------------------------------
 # Code
 # ----
 #
 #
-PATH="/opt/homebrew/opt/grep/libexec/gnubin:$PATH"
+prepend_to_path "/opt/homebrew/opt/grep/libexec/gnubin"
 export PATH
 
 echo ". Using GNU grep/egrep/fgrep."

--- a/ibin/envfor-homebrew
+++ b/ibin/envfor-homebrew
@@ -3,19 +3,19 @@
 # Purpose   : Activate use of Homebrew's installed utilities.
 # Created   : Saturday, April  6 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-24 13:07:44 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:02:35 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
 #
 # Add support for Homebrew on macOS.
-# Supports the x86 and Apple Silicon architectures.
+# Supports Homebrew for macOS on Intel and Apple Silicon architectures.
 
 # ----------------------------------------------------------------------------
 # Dependencies
 # ------------
 #
-# Support Homebrew for macOS on Intel and Apple Silicon architectures.
+# - USRHOME function prepend_to_path
 
 # ----------------------------------------------------------------------------
 # Code
@@ -88,7 +88,8 @@ if ! echo "$PATH" | grep -E "(/homebrew/|/usr/local/Cellar|/usr/local/opt/)" > /
 /usr/local/bin:\
 /usr/local/sbin:\
 /usr/local/opt/m4/bin
-                PATH=${usrhome_homebrew_path}:$PATH
+
+                prepend_to_path ${usrhome_homebrew_path}
                 export PATH
                 if [ "$USRHOME_SHOW_PATH_ACTIVATION" = "1" ]; then
                     usrhome_printf "- Using Homebrew tools from /usr/local and /usr/local/Cellar\n"
@@ -128,7 +129,8 @@ if ! echo "$PATH" | grep -E "(/homebrew/|/usr/local/Cellar|/usr/local/opt/)" > /
 /opt/homebrew/bin:\
 /opt/homebrew/sbin:\
 /opt/homebrew/opt/m4/bin
-                PATH=${usrhome_homebrew_path}:$PATH
+
+                prepend_to_path ${usrhome_homebrew_path}
                 export PATH
                 if [ "$USRHOME_SHOW_PATH_ACTIVATION" = "1" ]; then
                     usrhome_printf "- Using Homebrew tools from /opt/homebrew.\n"

--- a/ibin/envfor-llvm
+++ b/ibin/envfor-llvm
@@ -3,7 +3,7 @@
 # Purpose   : Activate LLVM tools in the current shell.
 # Created   : Tuesday, December 23 2025.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-02-18 16:57:23 EST, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:01:46 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -19,6 +19,7 @@
 #
 # - Support for macOS via Homebrew.
 # - printf
+# - USRHOME function  prepend_to_path
 
 # ----------------------------------------------------------------------------
 # Code
@@ -79,7 +80,7 @@ if [ -z "$USRHOME_USING_LLVM" ]; then
     esac
 
     # Add llvm/bin to PATH
-    PATH="$(brew --prefix llvm)/bin:$PATH"
+    prepend_to_path "$(brew --prefix llvm)/bin"
     export PATH
 
     # Add llvm/lib to LIB

--- a/ibin/setfor-path
+++ b/ibin/setfor-path
@@ -3,7 +3,7 @@
 # Purpose   : Add USRHOME directories to PATH.
 # Created   : Saturday, March 30 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-25 16:31:42 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 13:34:25 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -26,7 +26,66 @@
 #
 usrhome_trace_in "\$USRHOME_DIR/ibin/setfor-path"
 
-# ------------
+# ----------------------------------------------------------------------------
+# Topic: PATH management
+# ----------------------
+#
+# Define functions that append and prepend directories to PATH
+
+# POSIX-compliant function to append to PATH uniquely
+# - Does not export PATH.  Caller must do it.
+append_to_path()
+{
+    # Arg: 1  a :-separated list of directories
+    _usrhome_new_dirs="$1"
+
+    # Use a here-document to pipe the list into a while loop.
+    # This is a robust POSIX way to split strings without changing IFS globally.
+    printf '%s\n' "$_usrhome_new_dirs" | tr ':' '\n' | while read -r _usrhome_dir; do
+        # Skip empty lines
+        [ -z "$_usrhome_dir" ] && continue
+
+        # Skip if the directory does not exist
+        [ ! -d "$_usrhome_dir" ] && continue
+
+        # Check if dir is already in PATH
+        case ":$PATH:" in
+            *:"$_usrhome_dir":*) ;;                  # skip if already present
+            *) PATH="${PATH:+$PATH:}$_usrhome_dir" ;; # Append to PATH
+        esac
+    done
+    unset _usrhome_new_dirs _usrhome_dir
+}
+
+
+
+# POSIX-compliant function to prepend to PATH uniquely
+# - Does not export PATH.  Caller must do it.
+prepend_to_path()
+{
+    # Arg: 1  a :-separated list of directories
+    _usrhome_new_dirs="$1"
+
+    # Use a here-document to pipe the list into a while loop.
+    # This is a robust POSIX way to split strings without changing IFS globally.
+    printf '%s\n' "$_usrhome_new_dirs" | tr ':' '\n' | while read -r _usrhome_dir; do
+        # Skip empty lines
+        [ -z "$_usrhome_dir" ] && continue
+
+        # Skip if the directory does not exist
+        [ ! -d "$_usrhome_dir" ] && continue
+
+        # Check if dir is already in PATH
+        case ":$PATH:" in
+            *:"$_usrhome_dir":*) ;;                  # skip if already present
+            *) PATH="$_usrhome_dir${PATH:+:$PATH}" ;; # Prepend to PATH
+        esac
+    done
+    unset _usrhome_new_dirs _usrhome_dir
+}
+
+
+# ----------------------------------------------------------------------------
 
 if [ -z "$USRHOME__IN_LOGIN" ] || [ "$USRHOME_CONFIG_AT_LOGIN" = "1" ]; then
     # if not a login shell OR user allows configuration at login...

--- a/ibin/setfor-path
+++ b/ibin/setfor-path
@@ -3,7 +3,7 @@
 # Purpose   : Add USRHOME directories to PATH.
 # Created   : Saturday, March 30 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-27 14:28:50 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 15:06:53 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -38,40 +38,20 @@ append_to_path()
 {
     # Arg: 1  a :-separated list of directories
     _usrhome_new_dirs="$1"
+    _usrhome_remainder="$_usrhome_new_dirs"
 
-    # Use a here-document to pipe the list into a while loop.
-    # This is a robust POSIX way to split strings without changing IFS globally.
-    printf '%s\n' "$_usrhome_new_dirs" | tr ':' '\n' | while read -r _usrhome_dir; do
-        # Skip empty lines
-        [ -z "$_usrhome_dir" ] && continue
+    while [ -n "$_usrhome_remainder" ]; do
+        # Extract the first directory from the remainder
+        _usrhome_dir="${_usrhome_remainder%%:*}"
 
-        # Skip if the directory does not exist
-        [ ! -d "$_usrhome_dir" ] && continue
+        # Advance past this entry (handle single-element case)
+        if [ "$_usrhome_dir" = "$_usrhome_remainder" ]; then
+            _usrhome_remainder=""
+        else
+            _usrhome_remainder="${_usrhome_remainder#*:}"
+        fi
 
-        # Check if dir is already in PATH
-        case ":$PATH:" in
-            *:"$_usrhome_dir":*) ;;                  # skip if already present
-            *) PATH="${PATH:+$PATH:}$_usrhome_dir" ;; # Append to PATH
-        esac
-    done
-    unset _usrhome_new_dirs _usrhome_dir
-}
-
-# POSIX-compliant function to prepend to PATH uniquely
-# - Does not export PATH.  Caller must do it.
-prepend_to_path()
-{
-    # Arg: 1  a :-separated list of directories
-    _usrhome_new_dirs="$1"
-
-    # Reverse the list so that prepending one-by-one preserves the original order.
-    # e.g. "A:B:C" → iterate C, B, A → PATH = A:B:C:$PATH
-    printf '%s\n' "$_usrhome_new_dirs" | tr ':' '\n' \
-        | awk '{a[NR]=$0} END{for(i=NR;i>=1;i--) print a[i]}' \
-        | while read -r _usrhome_dir; do
-
-        echo "-----> process: $_usrhome_dir"
-        # Skip empty lines
+        # Skip empty entries
         [ -z "$_usrhome_dir" ] && continue
 
         # Skip if the directory does not exist
@@ -80,11 +60,58 @@ prepend_to_path()
         # Check if dir is already in PATH
         case ":$PATH:" in
             *:"$_usrhome_dir":*) ;;                   # skip if already present
-            *) PATH="$_usrhome_dir${PATH:+:$PATH}" ;; # Prepend to PATH
+            *) PATH="${PATH:+$PATH:}$_usrhome_dir" ;; # Append to PATH
         esac
     done
-    unset _usrhome_new_dirs _usrhome_dir
+    unset _usrhome_new_dirs _usrhome_remainder _usrhome_dir
 }
+
+# POSIX-compliant function to prepend to PATH uniquely
+# - Does not export PATH.  Caller must do it.
+prepend_to_path()
+{
+    # Arg: 1  a :-separated list of directories
+    _usrhome_new_dirs="$1"
+    _usrhome_remainder="$_usrhome_new_dirs"
+    _usrhome_prefix=""
+
+    while [ -n "$_usrhome_remainder" ]; do
+        # Extract the first directory from the remainder
+        _usrhome_dir="${_usrhome_remainder%%:*}"
+
+        # Advance past this entry (handle single-element case)
+        if [ "$_usrhome_dir" = "$_usrhome_remainder" ]; then
+            _usrhome_remainder=""
+        else
+            _usrhome_remainder="${_usrhome_remainder#*:}"
+        fi
+
+        # Skip empty entries
+        [ -z "$_usrhome_dir" ] && continue
+
+        # Skip if the directory does not exist
+        [ ! -d "$_usrhome_dir" ] && continue
+
+        # Skip if already in PATH
+        case ":$PATH:" in
+            *:"$_usrhome_dir":*) continue ;;
+        esac
+
+        # Skip if already accumulated in the prefix (dedup within input list)
+        case ":$_usrhome_prefix:" in
+            *:"$_usrhome_dir":*) continue ;;
+        esac
+
+        # Collect in original order: prefix grows as A → A:B → A:B:C
+        _usrhome_prefix="${_usrhome_prefix:+$_usrhome_prefix:}$_usrhome_dir"
+    done
+
+    # Prepend the whole collected prefix to PATH in a single step
+    [ -n "$_usrhome_prefix" ] && PATH="${_usrhome_prefix}${PATH:+:$PATH}"
+
+    unset _usrhome_new_dirs _usrhome_remainder _usrhome_dir _usrhome_prefix
+}
+
 
 
 # ----------------------------------------------------------------------------

--- a/ibin/setfor-path
+++ b/ibin/setfor-path
@@ -3,7 +3,7 @@
 # Purpose   : Add USRHOME directories to PATH.
 # Created   : Saturday, March 30 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-27 15:06:53 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 15:13:22 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -37,8 +37,7 @@ usrhome_trace_in "\$USRHOME_DIR/ibin/setfor-path"
 append_to_path()
 {
     # Arg: 1  a :-separated list of directories
-    _usrhome_new_dirs="$1"
-    _usrhome_remainder="$_usrhome_new_dirs"
+    _usrhome_remainder="$1"
 
     while [ -n "$_usrhome_remainder" ]; do
         # Extract the first directory from the remainder
@@ -63,7 +62,7 @@ append_to_path()
             *) PATH="${PATH:+$PATH:}$_usrhome_dir" ;; # Append to PATH
         esac
     done
-    unset _usrhome_new_dirs _usrhome_remainder _usrhome_dir
+    unset _usrhome_remainder _usrhome_dir
 }
 
 # POSIX-compliant function to prepend to PATH uniquely
@@ -71,8 +70,7 @@ append_to_path()
 prepend_to_path()
 {
     # Arg: 1  a :-separated list of directories
-    _usrhome_new_dirs="$1"
-    _usrhome_remainder="$_usrhome_new_dirs"
+    _usrhome_remainder="$1"
     _usrhome_prefix=""
 
     while [ -n "$_usrhome_remainder" ]; do
@@ -109,7 +107,7 @@ prepend_to_path()
     # Prepend the whole collected prefix to PATH in a single step
     [ -n "$_usrhome_prefix" ] && PATH="${_usrhome_prefix}${PATH:+:$PATH}"
 
-    unset _usrhome_new_dirs _usrhome_remainder _usrhome_dir _usrhome_prefix
+    unset _usrhome_remainder _usrhome_dir _usrhome_prefix
 }
 
 

--- a/ibin/setfor-path
+++ b/ibin/setfor-path
@@ -3,7 +3,7 @@
 # Purpose   : Add USRHOME directories to PATH.
 # Created   : Saturday, March 30 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-27 13:34:25 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:28:50 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -57,8 +57,6 @@ append_to_path()
     unset _usrhome_new_dirs _usrhome_dir
 }
 
-
-
 # POSIX-compliant function to prepend to PATH uniquely
 # - Does not export PATH.  Caller must do it.
 prepend_to_path()
@@ -66,9 +64,13 @@ prepend_to_path()
     # Arg: 1  a :-separated list of directories
     _usrhome_new_dirs="$1"
 
-    # Use a here-document to pipe the list into a while loop.
-    # This is a robust POSIX way to split strings without changing IFS globally.
-    printf '%s\n' "$_usrhome_new_dirs" | tr ':' '\n' | while read -r _usrhome_dir; do
+    # Reverse the list so that prepending one-by-one preserves the original order.
+    # e.g. "A:B:C" → iterate C, B, A → PATH = A:B:C:$PATH
+    printf '%s\n' "$_usrhome_new_dirs" | tr ':' '\n' \
+        | awk '{a[NR]=$0} END{for(i=NR;i>=1;i--) print a[i]}' \
+        | while read -r _usrhome_dir; do
+
+        echo "-----> process: $_usrhome_dir"
         # Skip empty lines
         [ -z "$_usrhome_dir" ] && continue
 
@@ -77,7 +79,7 @@ prepend_to_path()
 
         # Check if dir is already in PATH
         case ":$PATH:" in
-            *:"$_usrhome_dir":*) ;;                  # skip if already present
+            *:"$_usrhome_dir":*) ;;                   # skip if already present
             *) PATH="$_usrhome_dir${PATH:+:$PATH}" ;; # Prepend to PATH
         esac
     done

--- a/ibin/setfor-path
+++ b/ibin/setfor-path
@@ -3,7 +3,7 @@
 # Purpose   : Add USRHOME directories to PATH.
 # Created   : Saturday, March 30 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2026-04-27 15:13:22 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 15:15:14 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -33,6 +33,8 @@ usrhome_trace_in "\$USRHOME_DIR/ibin/setfor-path"
 # Define functions that append and prepend directories to PATH
 
 # POSIX-compliant function to append to PATH uniquely
+# - Tilde (~) is NOT expanded inside the argument; pass "$HOME/bin"
+#   instead of "~/bin", or let the shell expand ~ before the call.
 # - Does not export PATH.  Caller must do it.
 append_to_path()
 {
@@ -66,6 +68,8 @@ append_to_path()
 }
 
 # POSIX-compliant function to prepend to PATH uniquely
+# - Tilde (~) is NOT expanded inside the argument; pass "$HOME/bin"
+#   instead of "~/bin", or let the shell expand ~ before the call.
 # - Does not export PATH.  Caller must do it.
 prepend_to_path()
 {

--- a/readme.rst
+++ b/readme.rst
@@ -1244,19 +1244,28 @@ USRHOME Command Name               Description
                                    - Examples:
 
                                      - ``append_to_path ~/my-bin``
-                                     - ``append_to_path ~/my-bin:~/other-bin``
+                                     - ``append_to_path ~/my-bin:$HOME/other-bin``
+                                     - ``append_to_path $HOME/my-bin:$HOME/other-bin``
+
+                                   - **Caution**: shells only expand the ~ at the beginning
+                                     of strings, therefore you cannot use it elsewhere in the
+                                     list!
 
 ``prepend_to_path DIRS``           Prepend directories to PATH.
 
                                    - DIRS is either one directory or a list a
                                      colon-separated directories.
-                                   - Appends only the directories that exits
+                                   - Prepends only the directories that exits
                                      and are not already present in PATH.
                                     - Examples:
 
                                      - ``prepend_to_path ~/my-bin``
-                                     - ``prepend_to_path ~/my-bin:~/other-bin``
+                                     - ``prepend_to_path ~/my-bin:$HOME/other-bin``
+                                     - ``prepend_to_path $HOME/my-bin:$HOME/other-bin``
 
+                                   - **Caution**: shells only expand the ~ at the beginning
+                                     of strings, therefore you cannot use it elsewhere in the
+                                     list!
 
 ``showpath [-n] [varname][PATH]``  Print the value of PATH, MANPATH or LIBPATH, or any PATH
                                    specific environment variable placing each directory

--- a/readme.rst
+++ b/readme.rst
@@ -1235,6 +1235,29 @@ USRHOME Command Name               Description
 
                                    - This is an alias to `usrhome/ibin/envfor-info`_
 
+``append_to_path DIRS``            Append directories to PATH.
+
+                                   - DIRS is either one directory or a list a
+                                     colon-separated directories.
+                                   - Appends only the directories that exits
+                                     and are not already present in PATH.
+                                   - Examples:
+
+                                     - ``append_to_path ~/my-bin``
+                                     - ``append_to_path ~/my-bin:~/other-bin``
+
+``prepend_to_path DIRS``           Prepend directories to PATH.
+
+                                   - DIRS is either one directory or a list a
+                                     colon-separated directories.
+                                   - Appends only the directories that exits
+                                     and are not already present in PATH.
+                                    - Examples:
+
+                                     - ``prepend_to_path ~/my-bin``
+                                     - ``prepend_to_path ~/my-bin:~/other-bin``
+
+
 ``showpath [-n] [varname][PATH]``  Print the value of PATH, MANPATH or LIBPATH, or any PATH
                                    specific environment variable placing each directory
                                    in its own line.

--- a/template/usrcfg/ibin/envfor-curl-hb
+++ b/template/usrcfg/ibin/envfor-curl-hb
@@ -3,7 +3,7 @@
 # Purpose   : Environment to use the Homebrew version of curl.
 # Created   : Sunday, March 31 2024.
 # Author    : Pierre Rouleau <prouleau001@gmail.com>
-# Time-stamp: <2024-04-19 16:18:56 EDT, updated by Pierre Rouleau>
+# Time-stamp: <2026-04-27 14:00:55 EDT, updated by Pierre Rouleau>
 # ----------------------------------------------------------------------------
 # Module Description
 # ------------------
@@ -21,7 +21,7 @@
 # Dependencies
 # ------------
 #
-#
+# USRHOME function  prepend_to_path
 
 
 # ----------------------------------------------------------------------------
@@ -31,7 +31,8 @@
 #
 if ! echo $PATH | grep "/opt/homebrew/opt/curl/bin" > /dev/null; then
     echo "- Adding Homebrew curl support"
-    export PATH="/opt/homebrew/opt/curl/bin:$PATH"
+    prepend_to_path "/opt/homebrew/opt/curl/bin"
+    export PATH
 fi
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
* These functions can prepend/append one or several directories to PATH, checking each directory and adding it only it exists and is not already present in the PATH value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added append_to_path and prepend_to_path commands to manage PATH from single or colon-separated directory lists, avoiding duplicates and skipping non-existent entries.

* **Refactor**
  * Environment activation scripts updated to use the new PATH helpers and explicitly export PATH for consistent behavior.

* **Documentation**
  * README updated with usage examples and a note about ~ expansion limitations.

* **Chores**
  * Updated header timestamps and dependency notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->